### PR TITLE
Archpath robustness

### DIFF
--- a/CMakeScripts/OCArchitecturePath.cmake
+++ b/CMakeScripts/OCArchitecturePath.cmake
@@ -83,7 +83,17 @@ function(getCompilerPathElem VARNAME)
 	elseif( CYGWIN )
 		set(_COMP "cygwin")
 	endif()
-	set(${VARNAME} "${_COMP}-${CMAKE_C_COMPILER_VERSION}" PARENT_SCOPE)
+	
+	# Get compiler major + minor versions
+	set(_COMPILER_VERSION_REGEX "^[0-9]+\.[0-9]+")
+	string(REGEX MATCH ${_COMPILER_VERSION_REGEX}
+       _C_COMPILER_VERSION_MM "${CMAKE_C_COMPILER_VERSION}")
+    # Also for the fortran compiler
+    string(REGEX MATCH ${_COMPILER_VERSION_REGEX}
+       _Fortran_COMPILER_VERSION_MM "${CMAKE_Fortran_COMPILER_VERSION}")
+    
+    # Combine into e.g. gnu-4.8-F4.5
+	set(${VARNAME} "${_COMP}-${_C_COMPILER_VERSION_MM}-F${_Fortran_COMPILER_VERSION_MM}" PARENT_SCOPE)
 endfunction()
 
 function(getBuildTypePathElem VARNAME)


### PR DESCRIPTION
only using major/minor compiler version numbers for archpath
added the fortran compiler version to the archpath
closes #9 
