### PR TITLE
fix for component configuration

### DIFF
--- a/CMakeScripts/OCCollectComponentDefinitions.cmake
+++ b/CMakeScripts/OCCollectComponentDefinitions.cmake
@@ -51,11 +51,9 @@ endforeach()
 
 # Pass on local lookup flags (consumed by find_package calls)
 foreach(COMP ${OPENCMISS_COMPONENTS})
-    if (OC_SYSTEM_${COMP})
-        LIST(APPEND COMPONENT_COMMON_DEFS 
-            -DOC_SYSTEM_${COMP}=${OC_SYSTEM_${COMP}}
-        )
-    endif()
+    LIST(APPEND COMPONENT_COMMON_DEFS 
+        -DOC_SYSTEM_${COMP}=${OC_SYSTEM_${COMP}}
+    )
 endforeach()
 
 # Use the correct install RPATH to enable binaries to find the shared libs (if any, ignored otherwise).


### PR DESCRIPTION
the setting of OC_SYSTEM_<COMP> is now forwarded to the external projects in every case (ON|OFF)

previously, if a system component was temporarily enabled and disabled again it wasn't recognized
because OC_SYSTEM_<COMP> was only communicated in the case that it was set to 'ON'
(it was already correctly described in the documentation)
